### PR TITLE
Added snapshot functionality to models

### DIFF
--- a/automation/tests/test_airtable.py
+++ b/automation/tests/test_airtable.py
@@ -1,3 +1,4 @@
+import pytest
 from unittest import mock
 
 from ..clients import airtable
@@ -36,6 +37,31 @@ def get_foo_table_spec(status_to_cb=None):
 #########
 # TESTS #
 #########
+
+
+def test_snapshot_basic():
+    test_model = FooModel(
+        id=get_random_airtable_id(),
+        created_at=get_random_created_at(),
+        status="New",
+    )
+
+    # Getting modified fields before a snapshot should fail
+    with pytest.raises(RuntimeError):
+        test_model.get_modified_fields()
+
+    test_model.snapshot()
+    assert test_model.get_modified_fields() == set()
+
+    test_model.name = "bar"
+
+    assert test_model.get_modified_fields() == {"name"}
+    assert test_model.to_airtable(modified_only=True)["fields"].keys() == {
+        "name"
+    }
+
+    test_model.snapshot()
+    assert test_model.get_modified_fields() == set()
 
 
 def test_poll_table_basic():

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ pathspec==0.8.0
 pluggy==0.13.1
 pre-commit==2.9.2
 py==1.10.0
-pydantic==1.6.1
+pydantic==1.8
 PyJWT==1.7.1
 pyparsing==2.4.7
 pytest==6.2.0


### PR DESCRIPTION
When updating an airtable record from a model we only serialize changed fields.

Additionally, we can now mark derived or special fields as `allow_mutation=False` to ensure that the automation doesn't change them.

closes #52 